### PR TITLE
feat(day-4): add Elasticsearch service and dual-write on ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This service provides:
 
 ## Usage
 
-1. **Ingest an audit event**
+**Ingest an audit event**
 
     ```bash
     curl.exe -X POST "http://localhost:3000/audit" \
@@ -78,7 +78,7 @@ This service provides:
       -d "@payload.json"
     ```
 
-   **Response**:
+**Response**:
 
     ```json
     { "_id": "<generated_document_id>" }
@@ -86,9 +86,22 @@ This service provides:
 
 ## Query logs
 
+Examples:
+
     ```bash
     curl "http://localhost:3000/logs?service=orders&page=1&limit=20"
+
+   # Page 1 of 5 logs
+   curl "http://localhost:3000/logs?page=1&limit=5"
+
+   # Only events from service "orders"
+   curl "http://localhost:3000/logs?service=orders"
+
+   # Date-range filter
+   curl "http://localhost:3000/logs?start=2025-05-10T00:00:00Z&end=2025-05-12T23:59:59Z"
+
     ```
+
 
    **Query params:**
 
@@ -111,6 +124,11 @@ This service provides:
    ```bash
    # Build the Docker image
    docker build -t audit-logging-service .
+   ```
+
+   ```bash
+   # Build & run service + ES
+   docker-compose up --build
    ```
 
 # Run the container (reads your .env file)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,20 @@
-version: "3.8"
+version: '3.8'
 services:
   app:
     build: .
     ports:
-      - "3000:3000"
+      - '3000:3000'
     env_file:
       - .env
-# mongo, elasticsearch, etc. will be added on later days
+    depends_on:
+      - es
+
+  es:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
+    container_name: es
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+    ports:
+      - '9200:9200'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@elastic/elasticsearch": "^9.0.1",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "mongodb": "^6.16.0"
@@ -20,6 +21,38 @@
         "eslint-plugin-prettier": "^4.2.1",
         "globals": "^16.1.0",
         "prettier": "^2.8.8"
+      }
+    },
+    "node_modules/@elastic/elasticsearch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-9.0.1.tgz",
+      "integrity": "sha512-V/Hj/ePRiC6H8vOQF4GfOGIUFjYyA2C1Je6qKBD20AShmxqkaTRAQSvia4tvLobHqjrljUzb6khfhDuPrb6E8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@elastic/transport": "^9.0.1",
+        "apache-arrow": "18.x - 19.x",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@elastic/transport": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-9.0.1.tgz",
+      "integrity": "sha512-6jVZQzAe2iTRsZA6I/wkO2BjzJFD9BHTASo2YgGfbcoV95ey/8D/ABRhpgfg35LIDrmialIGJBizunSwxsRDLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "1.x",
+        "debug": "^4.4.0",
+        "hpagent": "^1.2.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^3.0.2",
+        "tslib": "^2.8.1",
+        "undici": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -186,6 +219,45 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.17.46",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.46.tgz",
+      "integrity": "sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -275,7 +347,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -287,12 +358,41 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-19.0.1.tgz",
+      "integrity": "sha512-APmMLzS4qbTivLrPdQXexGM4JRr+0g62QDaobzEvip/FdQIrv2qLy0mD5Qdmw4buydtVJgbFeKR8f59I6PPGDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -393,7 +493,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -406,11 +505,25 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -423,8 +536,45 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+      "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
+      "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -954,6 +1104,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -985,6 +1152,12 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.3.3",
@@ -1135,7 +1308,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1163,6 +1335,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/http-errors": {
@@ -1316,6 +1497,14 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -1376,6 +1565,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -1901,6 +2096,22 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/secure-json-parse": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
+      "integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/send": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
@@ -2087,13 +2298,25 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/text-table": {
@@ -2123,6 +2346,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2163,6 +2392,30 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.9.0.tgz",
+      "integrity": "sha512-e696y354tf5cFZPXsF26Yg+5M63+5H3oE6Vtkh2oqbvsE2Oe7s2nIbcQh5lmG7Lp/eS29vJtTpw9+p6PX0qNSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -2238,6 +2491,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
+      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/adarshnb95/audit-logging-service#readme",
   "dependencies": {
+    "@elastic/elasticsearch": "^9.0.1",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "mongodb": "^6.16.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,57 +1,78 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import { MongoClient } from 'mongodb';
+import { Client as ESClient } from '@elastic/elasticsearch';
 
 dotenv.config();
 const app = express();
 app.use(express.json());
 
-const client = new MongoClient(process.env.MONGODB_URI);
+const mongoClient = new MongoClient(process.env.MONGODB_URI);
+const esClient = new ESClient({ node: process.env.ES_NODE || 'http://localhost:9200' });
 
 async function start() {
   try {
     // Connect to MongoDB
-    await client.connect();
-    const db = client.db(); // uses the default database from the URI
+    await mongoClient.connect();
+    const db = mongoClient.db();
     const auditCollection = db.collection('audit_logs');
 
-    // Ingest audit events
+    // Initialize Elasticsearch index (ignore if it exists)
+    await esClient.indices.create(
+      { index: 'audit-logs' },
+      { ignore: [400] }
+    );
+
+    // POST /audit — ingest and index
     app.post('/audit', async (req, res) => {
       const { timestamp, service, eventType, userId, payload } = req.body;
       if (!timestamp || !service || !eventType || !userId) {
         return res.status(400).json({ error: 'Missing required fields' });
       }
+
       try {
+        // Write to MongoDB
         const result = await auditCollection.insertOne(req.body);
-        return res.status(201).json({ _id: result.insertedId });
+        const id = result.insertedId.toString();
+
+        // Write to Elasticsearch
+        try {
+          await esClient.index({
+            index: 'audit-logs',
+            id,
+            document: req.body
+          });
+        } catch (err) {
+          console.error('Elasticsearch indexing error:', err);
+        }
+
+        return res.status(201).json({ _id: id });
       } catch (err) {
-        console.error('Insert error', err);
+        console.error('Insert error:', err);
         return res.status(500).json({ error: 'Internal server error' });
       }
     });
 
-    // Query stored events with pagination & filters
+    // GET /logs — fetch paginated, filtered audit events
     app.get('/logs', async (req, res) => {
       const { service, eventType, start, end, page = 1, limit = 20 } = req.query;
 
-      // Build filter
       const filter = {};
-      if (service)    filter.service    = service;
-      if (eventType)  filter.eventType  = eventType;
+      if (service) filter.service = service;
+      if (eventType) filter.eventType = eventType;
       if (start || end) {
         filter.timestamp = {};
         if (start) filter.timestamp.$gte = new Date(start);
-        if (end)   filter.timestamp.$lte = new Date(end);
+        if (end) filter.timestamp.$lte = new Date(end);
       }
 
-      // Pagination
-      const pageNum  = parseInt(page,  10);
-      const pageSize = parseInt(limit, 10);
-      const skip     = (pageNum - 1) * pageSize;
+      const pageNum = Math.max(1, parseInt(page, 10));
+      const pageSize = Math.max(1, parseInt(limit, 10));
+      const skip = (pageNum - 1) * pageSize;
 
       try {
         const total = await auditCollection.countDocuments(filter);
-        const logs  = await auditCollection
+        const logs = await auditCollection
           .find(filter)
           .sort({ timestamp: -1 })
           .skip(skip)
@@ -60,24 +81,23 @@ async function start() {
 
         return res.json({ page: pageNum, limit: pageSize, total, logs });
       } catch (err) {
-        console.error('Query error', err);
+        console.error('Query error:', err);
         return res.status(500).json({ error: 'Internal server error' });
       }
     });
 
-    // Health-check endpoint
+    // GET /health — liveness check
     app.get('/health', (_req, res) => {
       res.json({ status: 'ok' });
     });
 
-    // Start listening
+    // Start server
     const PORT = process.env.PORT || 3000;
     app.listen(PORT, () => {
       console.log(`🚀 Listening on port ${PORT}`);
     });
-
   } catch (err) {
-    console.error('Failed to start', err);
+    console.error('Failed to start service:', err);
     process.exit(1);
   }
 }


### PR DESCRIPTION
Closes #4 

- Added Elasticsearch to docker-compose
- Installed @elastic/elasticsearch client
- Initialized 'audit-logs' index on startup
- Dual-write from POST /audit into ES
- Verified end-to-end ingestion and search