### PR TITLE
chore(day-9): final wrap-up testing, indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This service provides:
 
 2. **Install dependencies**
 ```bash
-    npm install
+   npm install
 ```
 
 3. **Configure environment**
@@ -177,23 +177,23 @@ curl.exe "http://localhost:3000/logs/search?q=test&service=test&page=1&limit=5"
 ## Kafka Ingestion
 
 1. Start Zookeeper & Kafka via Docker Compose:
-   ```bash
+```bash
    docker-compose up -d zookeeper kafka
-   ```
+```
 
 2. Produce an audit event:
-   ```bash
+```bash
    echo '{"timestamp":"…","service":"…","eventType":"…","userId":"…","payload":{}}' \
-  | docker exec -i kafka \
+      | docker exec -i kafka \
       /opt/bitnami/kafka/bin/kafka-console-producer.sh \
         --bootstrap-server localhost:9092 \
         --topic audit-events
-   ```
+```
 
 3. Search it:
-   ```bash
+```bash
    curl "http://localhost:3000/logs/search?q=<yourEventType>"
-   ```
+```
 
 ## Validation & Dead-Letter Handling
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     build: .
     ports:
-      - '3000:3000'
+      - '3001:3000'
     env_file:
       - .env
     depends_on:
@@ -42,7 +42,7 @@ services:
 
       # Listener definitions
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
 
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@elastic/elasticsearch": "^8.0.0",
         "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "kafkajs": "^2.2.4",
@@ -325,6 +326,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@elastic/elasticsearch": "^8.0.0",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "kafkajs": "^2.2.4",
@@ -36,4 +37,5 @@
     "globals": "^16.1.0",
     "prettier": "^2.8.8"
   }
+
 }


### PR DESCRIPTION
final wrap-up for validation, indexing, and search fixes

- Strip out Mongo’s _id before indexing into Elasticsearch  
- Add refresh: 'wait_for' so ES writes are immediately searchable  
- Use term filter on eventType (keyword) instead of eventType.keyword  
- Pre-create audit-logs index with proper mappings and wait_for yellow status  
- Move dead-letter TTL index creation into startup (not per-message)  
- Fixed dead-letter insert to use db.collection(), not auditCollection.db  
- Improved ES error logging in Kafka handler  
- Confirm top-level await works via type: module  
- Updated Pester tests for KAFKA_VALID and KAFKA_INVALID scenarios